### PR TITLE
revert(deps): revert `postcss` bump from `8.4.25` to `8.4.26`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11957,9 +11957,9 @@
 			"integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg=="
 		},
 		"postcss": {
-			"version": "8.4.26",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.26.tgz",
-			"integrity": "sha512-jrXHFF8iTloAenySjM/ob3gSj7pCu0Ji49hnjqzsgSRa50hkWCKD0HQ+gMNJkW38jBI68MpAAg7ZWwHwX8NMMw==",
+			"version": "8.4.25",
+			"resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.25.tgz",
+			"integrity": "sha512-7taJ/8t2av0Z+sQEvNzCkpDynl0tX3uJMCODi6nT3PfASC7dYCWV9aQ+uiCf+KBD4SEFcu+GvJdGdwzQ6OSjCw==",
 			"requires": {
 				"nanoid": "^3.3.6",
 				"picocolors": "^1.0.0",


### PR DESCRIPTION
# revert(deps): revert `postcss` bump from `8.4.25` to `8.4.26`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 18-07-2023 | 18-07-2023 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Revert `postcss` version bump from `8.4.25` to `8.4.26`

## 📋 Changes Made

### Dependencies
- Revert `postcss` from `8.4.26` back to `8.4.25`

## 🧪 Tests

- [x] Verify `postcss` version is reverted to `8.4.25`
- [x] Verify project builds without errors after revert

## 🔗 References

### Related PRs
- Reverts #379

### Files to modify
- `package-lock.json`