### PR TITLE
build(deps): bump `postcss` from `8.4.25` to `8.4.26`

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,7 @@
 		"eslint-plugin-vue": "^9.15.1",
 		"jest": "^29.6.1",
 		"jest-environment-jsdom": "^29.6.1",
-		"postcss": "^8.4.25",
+		"postcss": "^8.4.26",
 		"postcss-html": "^1.5.0",
 		"prettier": "^2.8.8",
 		"sass": "^1.63.6",


### PR DESCRIPTION
# build(deps): bump `postcss` from `8.4.25` to `8.4.26`

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 18-07-2023 | 18-07-2023 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [ ] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [ ] Configuration
- [ ] Documentation
- [ ] CI/CD

## 📝 Summary

- Bump `postcss` from `8.4.25` to `8.4.26`

## 📋 Changes Made

### Dependencies
- Bump `postcss` from `8.4.25` to `8.4.26`

## 🧪 Tests

- [x] Verify `postcss` and `8.4.26` is installed correctly
- [x] Verify CSS processing works without errors

## 🔗 References

### Documentation
- https://github.com/postcss/postcss
- https://github.com/postcss/postcss/blob/main/CHANGELOG.md
- https://github.com/postcss/postcss/compare/8.4.25...8.4.26
- https://github.com/postcss/postcss/releases