### PR TITLE
fix(deps): add overrides to reduce security vulnerabilities

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,5 +1,6 @@
 {
 	"compilerOptions": {
+		"ignoreDeprecations": "5.0",
 		"baseUrl": ".",
 		"paths": {
 			"~/*": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nuxt-course",
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nuxt-course",
-			"version": "2.3.5",
+			"version": "2.3.6",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -123,31 +123,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/extglob/node_modules/define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/to-regex/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/istanbul-lib-instrument/node_modules/semver": {
 			"version": "7.7.3",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
@@ -537,15 +512,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/expand-brackets/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
 		"node_modules/@nuxt/cli/node_modules/http-errors": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -604,18 +570,6 @@
 				}
 			],
 			"license": "BSD-3-Clause"
-		},
-		"node_modules/regex-not/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/css-property-sort-order-smacss": {
 			"version": "2.2.0",
@@ -887,19 +841,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/watchpack-chokidar2/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/array.prototype.flatmap": {
@@ -1540,18 +1481,6 @@
 				"sha.js": "^2.4.8"
 			}
 		},
-		"node_modules/object.pick": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
-			"integrity": "sha512-tqa/UMy/CCoYmj+H5qc07qvSL9dqcs/WZENZ1JbtWBlATP+iVOe778gE6MSijnyCnORzDuX6hU+LA4SZ09YjFQ==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/optimize-css-assets-webpack-plugin/node_modules/postcss-reduce-initial": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/postcss-reduce-initial/-/postcss-reduce-initial-5.1.2.tgz",
@@ -1719,19 +1648,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/snapdragon/node_modules/is-descriptor": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-accessor-descriptor": "^1.0.1",
-				"is-data-descriptor": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/jest-regex-util": {
 			"version": "30.0.1",
 			"resolved": "https://registry.npmjs.org/jest-regex-util/-/jest-regex-util-30.0.1.tgz",
@@ -1772,15 +1688,6 @@
 			"resolved": "https://registry.npmjs.org/is-whitespace/-/is-whitespace-0.3.0.tgz",
 			"integrity": "sha512-RydPhl4S6JwAyj0JJjshWJEFG6hNye3pZFBRZaTUfZFwGHxzppNaNOVgQuS/E/SlhrApuMXrpnK1EEIXfdo3Dg==",
 			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/repeat-element": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/repeat-element/-/repeat-element-1.1.4.tgz",
-			"integrity": "sha512-LFiNfRcSu7KK3evMyYOuCzv3L10TW7yC1G2/+StMjK8Y6Vqd2MG7r/Qjw4ghtuCOjFvlnms/iMmLqpvW/ES/WQ==",
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -2078,18 +1985,6 @@
 				"url": "https://opencollective.com/eslint"
 			}
 		},
-		"node_modules/set-value/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/postcss-discard-empty": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-discard-empty/-/postcss-discard-empty-7.0.1.tgz",
@@ -2100,25 +1995,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.32"
-			}
-		},
-		"node_modules/extglob": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
-			"integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-			"license": "MIT",
-			"dependencies": {
-				"array-unique": "^0.3.2",
-				"define-property": "^1.0.0",
-				"expand-brackets": "^2.1.4",
-				"extend-shallow": "^2.0.1",
-				"fragment-cache": "^0.2.1",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/yargs-parser": {
@@ -2175,27 +2051,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/ret": {
-			"version": "0.1.15",
-			"resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
-			"integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.12"
-			}
-		},
-		"node_modules/is-data-descriptor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.1.tgz",
-			"integrity": "sha512-bc4NlCDiCr28U4aEsQ3Qs2491gVq4V8G7MQyws968ImqjKuYtTJXrl7Vq7jsN7Ly/C3xj5KWFrY7sHNeDkAzXw==",
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/@vue/babel-sugar-v-on": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@vue/babel-sugar-v-on/-/babel-sugar-v-on-1.4.0.tgz",
@@ -2208,18 +2063,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/webpack/node_modules/is-number": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/watchpack-chokidar2/node_modules/anymatch": {
@@ -2343,18 +2186,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
-			}
-		},
-		"node_modules/mixin-deep/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/unicode-canonical-property-names-ecmascript": {
@@ -2502,15 +2333,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/to-regex/node_modules/safe-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-			"integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
-			"license": "MIT",
-			"dependencies": {
-				"ret": "~0.1.10"
-			}
-		},
 		"node_modules/fs.realpath": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
@@ -2574,25 +2396,6 @@
 			},
 			"engines": {
 				"node": ">=0.11.0"
-			}
-		},
-		"node_modules/snapdragon": {
-			"version": "0.8.2",
-			"resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.2.tgz",
-			"integrity": "sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==",
-			"license": "MIT",
-			"dependencies": {
-				"base": "^0.11.1",
-				"debug": "^2.2.0",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"map-cache": "^0.2.2",
-				"source-map": "^0.5.6",
-				"source-map-resolve": "^0.5.0",
-				"use": "^3.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stack-utils": {
@@ -2682,18 +2485,6 @@
 				"url": "https://github.com/chalk/chalk?sponsor=1"
 			}
 		},
-		"node_modules/to-regex/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/stylelint/node_modules/@csstools/selector-specificity": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/@csstools/selector-specificity/-/selector-specificity-5.0.0.tgz",
@@ -2760,6 +2551,7 @@
 			"resolved": "https://registry.npmjs.org/resolve-url/-/resolve-url-0.2.1.tgz",
 			"integrity": "sha512-ZuF55hVUQaaczgOIwqWzkEcEidmlD/xl44x1UZnhOXcYuFN2S6+rcxpG+C1N3So0wvNI3DmJICUFfu2SxhBmvg==",
 			"deprecated": "https://github.com/lydell/resolve-url#deprecated",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/eslint": {
@@ -2859,30 +2651,6 @@
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
 			}
 		},
-		"node_modules/babel-code-frame/node_modules/supports-color": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-			"integrity": "sha512-KKNVtd6pCYgPIKU4cp2733HWYCpplQhddZLBUryaAHou723x+FRzQ5Df824Fj+IyyuiQTRoub4SnIFfIcrp70g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/snapdragon-node": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
-			"integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
-			"license": "MIT",
-			"dependencies": {
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.0",
-				"snapdragon-util": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/get-symbol-description": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/get-symbol-description/-/get-symbol-description-1.1.0.tgz",
@@ -2938,18 +2706,6 @@
 			"integrity": "sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==",
 			"dev": true,
 			"license": "ISC"
-		},
-		"node_modules/to-regex/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/public-encrypt": {
 			"version": "4.0.3",
@@ -3363,18 +3119,6 @@
 			"integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
 			"license": "MIT"
 		},
-		"node_modules/has-values/node_modules/is-number/node_modules/kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/connect/node_modules/finalhandler": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.1.2.tgz",
@@ -3729,24 +3473,6 @@
 				"node": "^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0"
 			}
 		},
-		"node_modules/expand-brackets": {
-			"version": "2.1.4",
-			"resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
-			"integrity": "sha512-w/ozOKR9Obk3qoWeY/WDi6MFta9AoMR+zud60mdnbniMcBxRuFJyDt2LdX/14A1UABeqk+Uk+LDfUpvoGKppZA==",
-			"license": "MIT",
-			"dependencies": {
-				"debug": "^2.3.3",
-				"define-property": "^0.2.5",
-				"extend-shallow": "^2.0.1",
-				"posix-character-classes": "^0.1.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "8.47.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.47.0.tgz",
@@ -3769,19 +3495,6 @@
 			"peerDependencies": {
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <6.0.0"
-			}
-		},
-		"node_modules/is-descriptor": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.3.tgz",
-			"integrity": "sha512-JCNNGbwWZEVaSPtS45mdtrneRWJFp07LLmykxeFV5F6oBvNF8vHSfJuJgoT472pSfk+Mf8VnlrspaFBHWM8JAw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-accessor-descriptor": "^1.0.1",
-				"is-data-descriptor": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/write-json-file/node_modules/pify": {
@@ -4631,15 +4344,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/get-value": {
-			"version": "2.0.6",
-			"resolved": "https://registry.npmjs.org/get-value/-/get-value-2.0.6.tgz",
-			"integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@nuxt/cli/node_modules/serve-static": {
 			"version": "1.16.2",
 			"resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
@@ -4653,18 +4357,6 @@
 			},
 			"engines": {
 				"node": ">= 0.8.0"
-			}
-		},
-		"node_modules/base/node_modules/define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/is-bigint": {
@@ -4885,21 +4577,6 @@
 				"axios-retry": "^3.1.9",
 				"consola": "^2.15.3",
 				"defu": "^5.0.0"
-			}
-		},
-		"node_modules/union-value": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.1.tgz",
-			"integrity": "sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==",
-			"license": "MIT",
-			"dependencies": {
-				"arr-union": "^3.1.0",
-				"get-value": "^2.0.6",
-				"is-extendable": "^0.1.1",
-				"set-value": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/glob-all/node_modules/wrap-ansi": {
@@ -5154,6 +4831,7 @@
 			"version": "0.2.2",
 			"resolved": "https://registry.npmjs.org/decode-uri-component/-/decode-uri-component-0.2.2.tgz",
 			"integrity": "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10"
@@ -5814,12 +5492,14 @@
 			}
 		},
 		"node_modules/axios": {
-			"version": "0.21.4",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.21.4.tgz",
-			"integrity": "sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==",
+			"version": "1.13.2",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+			"integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
 			"license": "MIT",
 			"dependencies": {
-				"follow-redirects": "^1.14.0"
+				"follow-redirects": "^1.15.6",
+				"form-data": "^4.0.4",
+				"proxy-from-env": "^1.1.0"
 			}
 		},
 		"node_modules/diffie-hellman/node_modules/bn.js": {
@@ -5988,30 +5668,6 @@
 			"resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
 			"integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
 			"license": "MIT"
-		},
-		"node_modules/split-string/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/class-utils/node_modules/define-property": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/read-pkg-up/node_modules/type-fest": {
 			"version": "0.8.1",
@@ -6358,21 +6014,6 @@
 				"rimraf": "bin.js"
 			}
 		},
-		"node_modules/@vue/component-compiler-utils/node_modules/picocolors": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-0.2.1.tgz",
-			"integrity": "sha512-cMlDqaLEqfSaW8Z7N5Jw+lyIW869EzT73/F5lhtY9cLGoVxSXznfgfXMO0Z5K0o0Q2TkTXq+0KFsdnSe3jDViA==",
-			"license": "ISC"
-		},
-		"node_modules/array-unique": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/array-unique/-/array-unique-0.3.2.tgz",
-			"integrity": "sha512-SleRWjh9JUud2wH1hPs9rZBZ33H6T9HOiL0uwGnGx9FpE6wKGyfWugmbkEOIs6qWrZhg0LWeLziLrEwQJhs5mQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/jest-leak-detector": {
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/jest-leak-detector/-/jest-leak-detector-30.2.0.tgz",
@@ -6658,28 +6299,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/watchpack-chokidar2/node_modules/braces": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/hashery": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/hashery/-/hashery-1.2.0.tgz",
@@ -6959,15 +6578,6 @@
 				"node": ">=20"
 			}
 		},
-		"node_modules/assign-symbols": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/assign-symbols/-/assign-symbols-1.0.0.tgz",
-			"integrity": "sha512-Q+JC7Whu8HhmTdBph/Tq59IoRtoy6KAm5zzPv00WdujX82lbAL8K7WVjne7vdCsAmbF4AYaDOPyO3k0kl8qIrw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/error-stack-parser": {
 			"version": "2.1.4",
 			"resolved": "https://registry.npmjs.org/error-stack-parser/-/error-stack-parser-2.1.4.tgz",
@@ -6994,19 +6604,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/collection-visit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
-			"integrity": "sha512-lNkKvzEeMBBjUGHZ+q6z9pSJla0KWAQPvtzhEV9+iGyQYG+pBpl7xKDhxoNSOZH2hhv0v5k0y2yAM4o4SjoSkw==",
-			"license": "MIT",
-			"dependencies": {
-				"map-visit": "^1.0.0",
-				"object-visit": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@types/stack-utils/-/stack-utils-2.0.3.tgz",
@@ -7030,18 +6627,6 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/to-object-path": {
-			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
-			"integrity": "sha512-9mWHdnGRuh3onocaHzukyvCZhzvr6tiflAy/JRFXcJX0TjgfWA9pk9t8CMbzmBE4Jfw58pXbkngtBtqYxzNEyg==",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/postcss-modules-extract-imports": {
@@ -7112,18 +6697,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/unset-value/node_modules/has-value/node_modules/isobject": {
-			"version": "2.1.0",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
-			"integrity": "sha512-+OUdGJlgjOBZDfxnDjYYG6zp487z0JGNQq3cYQYg5f5hKR+syHMsaztzGeml/4kGG55CSpKSpWTY+jYGgsHLgA==",
-			"license": "MIT",
-			"dependencies": {
-				"isarray": "1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@csstools/postcss-media-minmax": {
 			"version": "1.1.8",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-media-minmax/-/postcss-media-minmax-1.1.8.tgz",
@@ -7182,15 +6755,6 @@
 			},
 			"engines": {
 				"node": ">=18"
-			}
-		},
-		"node_modules/snapdragon/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
 			}
 		},
 		"node_modules/@babel/plugin-transform-unicode-property-regex": {
@@ -7692,20 +7256,11 @@
 				"node": ">= 0.8.0"
 			}
 		},
-		"node_modules/babel-code-frame/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
 			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/create-ecdh": {
@@ -7786,31 +7341,6 @@
 				"mime-types": "^2.1.19",
 				"on-finished": "^2.3.0",
 				"vary": "^1.1.2"
-			}
-		},
-		"node_modules/watchpack-chokidar2/node_modules/micromatch": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint-order": {
@@ -8055,6 +7585,7 @@
 			"resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
 			"integrity": "sha512-Am1ousAhSLBeB9cG/7k7r2R0zj50uDRlZHPGbazid5s9rlF1F/QKYObEKSIunSjIOkJZqwRRLpvewjEkM7pSqg==",
 			"deprecated": "Please see https://github.com/lydell/urix#deprecated",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/pako": {
@@ -8467,33 +7998,11 @@
 				"node": ">=v18"
 			}
 		},
-		"node_modules/split-string/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/minizlib/node_modules/yallist": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
 			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
 			"license": "ISC"
-		},
-		"node_modules/arr-union": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
-			"integrity": "sha512-sKpyeERZ02v1FeCZT8lrfJq5u6goHCtpTAzPwJYe7c8SPFOboNjNg1vz2L4VTn9T4PQxEx13TbXLmYUcS6Ug7Q==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/postcss-html": {
 			"version": "1.8.0",
@@ -8640,18 +8149,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/has-values/node_modules/is-number": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@babel/plugin-transform-typeof-symbol": {
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typeof-symbol/-/plugin-transform-typeof-symbol-7.27.1.tgz",
@@ -8776,23 +8273,10 @@
 				"babel-types": "^6.26.0"
 			}
 		},
-		"node_modules/fragment-cache": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
-			"integrity": "sha512-GMBAbW9antB8iZRHLoGw0b3HANt57diZYFO/HL1JGIC1MjKrdmhxvrJbupnVvpys0zsz7yBApXdQyfepKly2kA==",
-			"license": "MIT",
-			"dependencies": {
-				"map-cache": "^0.2.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/is-plain-object": {
 			"version": "5.0.0",
 			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-5.0.0.tgz",
 			"integrity": "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q==",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -8903,27 +8387,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/webpack/node_modules/braces": {
-			"version": "2.3.2",
-			"resolved": "https://registry.npmjs.org/braces/-/braces-2.3.2.tgz",
-			"integrity": "sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==",
-			"license": "MIT",
-			"dependencies": {
-				"arr-flatten": "^1.1.0",
-				"array-unique": "^0.3.2",
-				"extend-shallow": "^2.0.1",
-				"fill-range": "^4.0.0",
-				"isobject": "^3.0.1",
-				"repeat-element": "^1.1.2",
-				"snapdragon": "^0.8.1",
-				"snapdragon-node": "^2.0.1",
-				"split-string": "^3.0.2",
-				"to-regex": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@babel/plugin-syntax-bigint": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-bigint/-/plugin-syntax-bigint-7.8.3.tgz",
@@ -8978,15 +8441,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.2.15"
-			}
-		},
-		"node_modules/isobject": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/isobject/-/isobject-3.0.1.tgz",
-			"integrity": "sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/webpackbar/node_modules/ansi-styles": {
@@ -9045,29 +8499,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/for-in": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
-			"integrity": "sha512-7EwmXrOjyL+ChxMhmG5lnW9MPt1aIeZEwKhQzoBUdTV0N3zuwWDZYVJatDvZ2OyzPUvdIAZDsCetk3coyMfcnQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/unset-value/node_modules/has-value": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
-			"integrity": "sha512-gpG936j8/MzaeID5Yif+577c17TxaDmhuyVgSwtnL/q8UUTySg8Mecb+8Cf1otgLoD7DDH75axp86ER7LFsf3Q==",
-			"license": "MIT",
-			"dependencies": {
-				"get-value": "^2.0.3",
-				"has-values": "^0.1.4",
-				"isobject": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/webpack/node_modules/chownr": {
@@ -9264,12 +8695,6 @@
 				"url": "https://opencollective.com/pkgr"
 			}
 		},
-		"node_modules/snapdragon/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
-		},
 		"node_modules/mkdirp": {
 			"version": "0.5.6",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
@@ -9399,20 +8824,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/object-copy": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
-			"integrity": "sha512-79LYn6VAb63zgtmAteVOWo9Vdj71ZVBy3Pbse+VqxDpEP83XuujMrGqHIwAXJ5I/aM0zU7dIyIAhifVTPrNItQ==",
-			"license": "MIT",
-			"dependencies": {
-				"copy-descriptor": "^0.1.0",
-				"define-property": "^0.2.5",
-				"kind-of": "^3.0.3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@unrs/resolver-binding-linux-riscv64-gnu": {
@@ -9653,6 +9064,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.1.tgz",
 			"integrity": "sha512-cPiFOTLUKvJFIg4SKVScy4ilPPW6rFgMgfuZJPNoDuMs3nC1HbMUycBoJw77xFIp6z1UJQJOfx6C9GMH80DiTw==",
 			"deprecated": "See https://github.com/lydell/source-map-url#deprecated",
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@xtuc/ieee754": {
@@ -9680,18 +9092,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.8.0"
-			}
-		},
-		"node_modules/nanomatch/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@nuxt/generator/node_modules/consola": {
@@ -9849,16 +9249,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/chalk/chalk?sponsor=1"
-			}
-		},
-		"node_modules/babel-traverse/node_modules/debug": {
-			"version": "2.6.9",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
 			}
 		},
 		"node_modules/globalthis": {
@@ -10247,15 +9637,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/write-json-file/node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@parcel/watcher-darwin-x64": {
 			"version": "2.5.1",
 			"resolved": "https://registry.npmjs.org/@parcel/watcher-darwin-x64/-/watcher-darwin-x64-2.5.1.tgz",
@@ -10338,13 +9719,6 @@
 					"url": "https://opencollective.com/fast-check"
 				}
 			],
-			"license": "MIT"
-		},
-		"node_modules/babel-code-frame/node_modules/js-tokens": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-			"integrity": "sha512-RjTcuD4xjtthQkaWH7dFlH85L+QaVtSoOyGdZ3g6HFhS9dFNDfLyqgm2NFe2X6cQpeFmt0452FJjFG5UameExg==",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/webpack/node_modules/make-dir": {
@@ -11551,18 +10925,6 @@
 				"babylon": "bin/babylon.js"
 			}
 		},
-		"node_modules/map-visit": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
-			"integrity": "sha512-4y7uGv8bd2WdM9vpQsiQNo41Ln1NvhvDRuVt0k2JZQ+ezN2uaQes7lZeZ+QQUHOLQAtDaBJ+7wCbi+ab/KFs+w==",
-			"license": "MIT",
-			"dependencies": {
-				"object-visit": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/webpack/node_modules/loader-utils": {
 			"version": "1.4.2",
 			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.2.tgz",
@@ -11818,15 +11180,12 @@
 			}
 		},
 		"node_modules/tmp": {
-			"version": "0.0.33",
-			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-			"integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
+			"integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
 			"license": "MIT",
-			"dependencies": {
-				"os-tmpdir": "~1.0.2"
-			},
 			"engines": {
-				"node": ">=0.6.0"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/jest-runtime/node_modules/glob": {
@@ -11863,19 +11222,6 @@
 			},
 			"engines": {
 				"node": ">= 0.10.0"
-			}
-		},
-		"node_modules/object-copy/node_modules/is-descriptor": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-accessor-descriptor": "^1.0.1",
-				"is-data-descriptor": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/@istanbuljs/load-nyc-config": {
@@ -12168,18 +11514,6 @@
 				"@babel/core": "^7.13.0"
 			}
 		},
-		"node_modules/split-string/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/sass": {
 			"version": "1.94.2",
 			"resolved": "https://registry.npmjs.org/sass/-/sass-1.94.2.tgz",
@@ -12377,31 +11711,20 @@
 			}
 		},
 		"node_modules/http-proxy-middleware": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-1.3.1.tgz",
-			"integrity": "sha512-13eVVDYS4z79w7f1+NPllJtOQFx/FdUW4btIvVRMaRlUY9VGstAbo5MOhLEuUgZFRHn3x50ufn25zkj/boZnEg==",
+			"version": "3.0.5",
+			"resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
+			"integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
 			"license": "MIT",
 			"dependencies": {
-				"@types/http-proxy": "^1.17.5",
+				"@types/http-proxy": "^1.17.15",
+				"debug": "^4.3.6",
 				"http-proxy": "^1.18.1",
-				"is-glob": "^4.0.1",
-				"is-plain-obj": "^3.0.0",
-				"micromatch": "^4.0.2"
+				"is-glob": "^4.0.3",
+				"is-plain-object": "^5.0.0",
+				"micromatch": "^4.0.8"
 			},
 			"engines": {
-				"node": ">=8.0.0"
-			}
-		},
-		"node_modules/expand-brackets/node_modules/define-property": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/abbrev": {
@@ -12438,18 +11761,6 @@
 			"integrity": "sha512-3sOlxmbKcSHMjlUXQZKQ06jOswE7oVkXPxmZdoB1r5l0q6gTFTQSHxNxOrCccElbW7dxNytifNEo8qidX2Vsig==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/is-accessor-descriptor": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.1.tgz",
-			"integrity": "sha512-YBUanLI8Yoihw923YeFUS5fs0fF2f5TSFTNiYAAzhhDscDa3lEqYuz1pDOEP5KvX94I9ey3vsqjJcLVFVU+3QA==",
-			"license": "MIT",
-			"dependencies": {
-				"hasown": "^2.0.0"
-			},
-			"engines": {
-				"node": ">= 0.10"
-			}
 		},
 		"node_modules/char-regex": {
 			"version": "1.0.2",
@@ -13063,19 +12374,6 @@
 				"loader-utils": "^1.0.2"
 			}
 		},
-		"node_modules/expand-brackets/node_modules/is-descriptor": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-accessor-descriptor": "^1.0.1",
-				"is-data-descriptor": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/object.groupby": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/object.groupby/-/object.groupby-1.0.3.tgz",
@@ -13132,19 +12430,6 @@
 			"dependencies": {
 				"lodash._reinterpolate": "^3.0.0",
 				"lodash.templatesettings": "^4.0.0"
-			}
-		},
-		"node_modules/mixin-deep": {
-			"version": "1.3.2",
-			"resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.2.tgz",
-			"integrity": "sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==",
-			"license": "MIT",
-			"dependencies": {
-				"for-in": "^1.0.2",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/postcss-focus-visible": {
@@ -13592,15 +12877,6 @@
 				"node": ">=0.8.0"
 			}
 		},
-		"node_modules/component-emitter": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-			"integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-			"license": "MIT",
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
 		"node_modules/jest-message-util/node_modules/ansi-styles": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
@@ -13631,20 +12907,6 @@
 			"resolved": "https://registry.npmjs.org/server-destroy/-/server-destroy-1.0.1.tgz",
 			"integrity": "sha512-rb+9B5YBIEzYcD6x2VKidaa+cqYBJQKnU4oe4E3ANwRRN56yk/ua1YCJT1n21NTS8w6CcOclAKNP3PhdCXKYtQ==",
 			"license": "ISC"
-		},
-		"node_modules/watchpack-chokidar2/node_modules/to-regex-range": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/@nuxtjs/stylelint-module/node_modules/stylelint-webpack-plugin": {
 			"version": "2.5.0",
@@ -13923,15 +13185,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/arr-diff": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-4.0.0.tgz",
-			"integrity": "sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/tough-cookie": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
@@ -13943,19 +13196,6 @@
 			},
 			"engines": {
 				"node": ">=16"
-			}
-		},
-		"node_modules/webpack/node_modules/to-regex-range": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
-			"integrity": "sha512-ZZWNfCjUokXXDGXFpZehJIkZqq91BcULFq/Pi7M5i4JnxXdhMKAK682z8bCW3o8Hj1wuuzoKcW3DfVzaP6VuNg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/babel-loader/node_modules/make-dir": {
@@ -14009,16 +13249,6 @@
 				"ansi-html-community": "0.0.8",
 				"html-entities": "^2.1.0",
 				"strip-ansi": "^6.0.0"
-			}
-		},
-		"node_modules/babel-traverse/node_modules/globals": {
-			"version": "9.18.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-			"integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@csstools/postcss-color-function": {
@@ -14100,20 +13330,6 @@
 			},
 			"peerDependencies": {
 				"postcss": "^8.4.32"
-			}
-		},
-		"node_modules/watchpack-chokidar2/node_modules/micromatch/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/coa/node_modules/color-name": {
@@ -14229,19 +13445,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=10"
-			}
-		},
-		"node_modules/static-extend": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
-			"integrity": "sha512-72E9+uLc27Mt718pMHt9VMNiAL4LMsmDbBva8mxWUCkT07fSzEGMYUCk0XWY6lp0j6RBAG4cJ3mWuZv2OE3s0g==",
-			"license": "MIT",
-			"dependencies": {
-				"define-property": "^0.2.5",
-				"object-copy": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@babel/generator": {
@@ -14612,16 +13815,6 @@
 			"integrity": "sha512-YEexkCpL4j03jn5SxaMHqcO6IuWuqm8JFUYhyCep7Ao89JIYmB8xoKhK7zXXJ9cCaNXpyNH5L3QtAmoxjoHW2w==",
 			"license": "MIT"
 		},
-		"node_modules/has-ansi/node_modules/ansi-regex": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha512-TIGnTpdo+E3+pCyAluZvtED5p5wCqLdezCyhPZzKPcxvFplEt4i+W7OONCKgeZFT3+y5NZZfOOS/Bdcanm1MYA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@csstools/postcss-trigonometric-functions/node_modules/@csstools/css-parser-algorithms": {
 			"version": "2.7.1",
 			"resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-2.7.1.tgz",
@@ -14720,19 +13913,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/define-property": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-2.0.2.tgz",
-			"integrity": "sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^1.0.2",
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/html-minifier-terser": {
@@ -15147,15 +14327,6 @@
 			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
 			"license": "0BSD"
 		},
-		"node_modules/use": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/use/-/use-3.1.1.tgz",
-			"integrity": "sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/sass-resources-loader": {
 			"version": "2.2.5",
 			"resolved": "https://registry.npmjs.org/sass-resources-loader/-/sass-resources-loader-2.2.5.tgz",
@@ -15319,6 +14490,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
+			"dev": true,
 			"license": "(MIT OR Apache-2.0)",
 			"bin": {
 				"atob": "bin/atob.js"
@@ -15825,18 +14997,6 @@
 				"node": ">= 8"
 			}
 		},
-		"node_modules/static-extend/node_modules/define-property": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/nuxt": {
 			"version": "2.18.1",
 			"resolved": "https://registry.npmjs.org/nuxt/-/nuxt-2.18.1.tgz",
@@ -16073,19 +15233,6 @@
 				"node": ">=10"
 			}
 		},
-		"node_modules/regex-not": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.2.tgz",
-			"integrity": "sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==",
-			"license": "MIT",
-			"dependencies": {
-				"extend-shallow": "^3.0.2",
-				"safe-regex": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@jest/reporters/node_modules/glob": {
 			"version": "10.5.0",
 			"resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
@@ -16157,18 +15304,6 @@
 				"url": "https://opencollective.com/parcel"
 			}
 		},
-		"node_modules/webpack/node_modules/is-number/node_modules/kind-of": {
-			"version": "3.2.2",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@babel/plugin-transform-dynamic-import": {
 			"version": "7.27.1",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-dynamic-import/-/plugin-transform-dynamic-import-7.27.1.tgz",
@@ -16182,6 +15317,15 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
+			}
+		},
+		"node_modules/form-data/node_modules/mime-db": {
+			"version": "1.52.0",
+			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+			"integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"node_modules/cssnano-utils": {
@@ -16395,15 +15539,6 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/unset-value/node_modules/has-values": {
-			"version": "0.1.4",
-			"resolved": "https://registry.npmjs.org/has-values/-/has-values-0.1.4.tgz",
-			"integrity": "sha512-J8S0cEdWuQbqD9//tlZxiMuMNmxB8PlEwvYwuxsTmR1G5RXUePEX/SJn7aD0GMLieuZYSwNH0cQuJGwnYunXRQ==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/execa": {
 			"version": "5.1.1",
 			"resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
@@ -16532,15 +15667,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
-			}
-		},
-		"node_modules/map-cache": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/map-cache/-/map-cache-0.2.2.tgz",
-			"integrity": "sha512-8y/eV9QQZCiyn1SprXSrCmqJN0yNRATe+PO8ztwqrvrbdRLA3eYJF0yaR0YayLWkMbsQSKWS9N2gPcGEc4UsZg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@nuxt/cli/node_modules/ansi-styles": {
@@ -16903,15 +16029,6 @@
 			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
 			"license": "MIT"
 		},
-		"node_modules/@nuxtjs/youch/node_modules/cookie": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/cookie/-/cookie-0.3.1.tgz",
-			"integrity": "sha512-+IJOX0OqlHCszo2mBUq+SrEbCj6w7Kpffqx60zYbPTFaO4+yYgRjHwcZNpWvaTylDHaV7PPmBHzSecZiMhtPgw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/@csstools/postcss-text-decoration-shorthand": {
 			"version": "3.0.7",
 			"resolved": "https://registry.npmjs.org/@csstools/postcss-text-decoration-shorthand/-/postcss-text-decoration-shorthand-3.0.7.tgz",
@@ -17224,6 +16341,12 @@
 			"engines": {
 				"node": ">=0.12.0"
 			}
+		},
+		"node_modules/asynckit": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+			"integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+			"license": "MIT"
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
@@ -17857,44 +16980,6 @@
 				"tslib": "^2.4.0"
 			}
 		},
-		"node_modules/webpack/node_modules/micromatch": {
-			"version": "3.1.10",
-			"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.10.tgz",
-			"integrity": "sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==",
-			"license": "MIT",
-			"dependencies": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"braces": "^2.3.1",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"extglob": "^2.0.4",
-				"fragment-cache": "^0.2.1",
-				"kind-of": "^6.0.2",
-				"nanomatch": "^1.2.9",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/has-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
-			"integrity": "sha512-IBXk4GTsLYdQ7Rvt+GRBrFSVEkmuOUy4re0Xjd9kJSUQpnTrWR4/y9RpfexN9vkAPMFuQoeWKwqzPozRTlasGw==",
-			"license": "MIT",
-			"dependencies": {
-				"get-value": "^2.0.6",
-				"has-values": "^1.0.0",
-				"isobject": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@nodelib/fs.stat": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
@@ -18242,15 +17327,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/sort-keys/node_modules/is-plain-obj": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
-			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/console-browserify": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.2.0.tgz",
@@ -18528,19 +17604,6 @@
 				"postcss": "^8.2.15"
 			}
 		},
-		"node_modules/has-ansi": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-			"integrity": "sha512-C8vBJ8DwUCx19vhm7urhTuUsr4/IyP6l4VzNQDv+ryHQObW3TTTp9yB68WpYgRe2bbaGuZ/se74IqFeVnMnLZg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/klona": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/klona/-/klona-2.0.6.tgz",
@@ -18637,19 +17700,6 @@
 			"resolved": "https://registry.npmjs.org/buffer-json/-/buffer-json-2.0.0.tgz",
 			"integrity": "sha512-+jjPFVqyfF1esi9fvfUs3NqM0pH1ziZ36VP4hmA/y/Ssfo/5w5xHKfTw9BwQjoJ1w/oVtpLomqwUHKdefGyuHw==",
 			"license": "MIT"
-		},
-		"node_modules/watchpack-chokidar2/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/thingies": {
 			"version": "2.5.0",
@@ -18874,11 +17924,17 @@
 			"integrity": "sha512-dYnhHh0nJoMfnkZs6GmmhFknAGRrLznOu5nc9ML+EJxGvrx6H7teuevqVqCuPcPK//3eDrrjQhehXVx9cnkGdw==",
 			"license": "MIT"
 		},
-		"node_modules/expand-brackets/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"license": "MIT"
+		"node_modules/combined-stream": {
+			"version": "1.0.8",
+			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"license": "MIT",
+			"dependencies": {
+				"delayed-stream": "~1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
 		},
 		"node_modules/hard-source-webpack-plugin/node_modules/pify": {
 			"version": "4.0.1",
@@ -19025,15 +18081,6 @@
 			"peerDependencies": {
 				"@csstools/css-parser-algorithms": "^2.7.1",
 				"@csstools/css-tokenizer": "^2.4.1"
-			}
-		},
-		"node_modules/os-tmpdir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@babel/plugin-transform-async-to-generator": {
@@ -19255,15 +18302,12 @@
 			}
 		},
 		"node_modules/is-plain-obj": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-3.0.0.tgz",
-			"integrity": "sha512-gwsOE28k+23GP1B6vFl1oVh/WOzmawBrKwo5Ev6wMKzPkaXaCDIQKzLnvsA42DRlbVTWorkgTKIviAKCWkfUwA==",
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
+			"integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
 			"license": "MIT",
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jest-config/node_modules/ci-info": {
@@ -19623,18 +18667,6 @@
 				"cuint": "^0.2.2"
 			}
 		},
-		"node_modules/babel-code-frame": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
-			"integrity": "sha512-XqYMR2dfdGMW+hd0IUZ2PwK+fGeFkOxZJ0wY+JaQAHzt1Zx8LcvpiZD2NiGkEG8qx0CfkAOr5xt76d1e8vG90g==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"chalk": "^1.1.3",
-				"esutils": "^2.0.2",
-				"js-tokens": "^3.0.2"
-			}
-		},
 		"node_modules/babel-preset-jest": {
 			"version": "30.2.0",
 			"resolved": "https://registry.npmjs.org/babel-preset-jest/-/babel-preset-jest-30.2.0.tgz",
@@ -19650,16 +18682,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.11.0 || ^8.0.0-beta.1"
-			}
-		},
-		"node_modules/babel-code-frame/node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.8.0"
 			}
 		},
 		"node_modules/@babel/plugin-syntax-decorators": {
@@ -19693,18 +18715,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0-0"
-			}
-		},
-		"node_modules/snapdragon/node_modules/define-property": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/stylelint/node_modules/postcss-selector-parser": {
@@ -19825,26 +18835,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/cache-base": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
-			"integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
-			"license": "MIT",
-			"dependencies": {
-				"collection-visit": "^1.0.0",
-				"component-emitter": "^1.2.1",
-				"get-value": "^2.0.6",
-				"has-value": "^1.0.0",
-				"isobject": "^3.0.1",
-				"set-value": "^2.0.0",
-				"to-object-path": "^0.3.0",
-				"union-value": "^1.0.0",
-				"unset-value": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/js-yaml": {
 			"version": "3.14.2",
 			"resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
@@ -19874,18 +18864,6 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/snapdragon-util": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
-			"integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-			"license": "MIT",
-			"dependencies": {
-				"kind-of": "^3.2.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@csstools/selector-specificity": {
@@ -19927,19 +18905,6 @@
 			"dependencies": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
-			}
-		},
-		"node_modules/class-utils/node_modules/is-descriptor": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-accessor-descriptor": "^1.0.1",
-				"is-data-descriptor": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
 			}
 		},
 		"node_modules/safe-array-concat": {
@@ -20111,6 +19076,15 @@
 			"integrity": "sha512-oeVtt7eWQS+Na6F//S4kJ2K2VbRlS9D43mAlMyVpVWovy9o+jfgH8O9agzANzaiLjclA0oYzUXEM4PurhSUChw==",
 			"license": "MIT"
 		},
+		"node_modules/delayed-stream": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+			"integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.4.0"
+			}
+		},
 		"node_modules/diff-sequences": {
 			"version": "27.5.1",
 			"resolved": "https://registry.npmjs.org/diff-sequences/-/diff-sequences-27.5.1.tgz",
@@ -20229,18 +19203,6 @@
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/nanomatch/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/lodash.upperfirst": {
@@ -20390,19 +19352,6 @@
 				"webpack": "3 || 4 || 5"
 			}
 		},
-		"node_modules/loose-envify": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
-			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"js-tokens": "^3.0.0 || ^4.0.0"
-			},
-			"bin": {
-				"loose-envify": "cli.js"
-			}
-		},
 		"node_modules/which-collection": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/which-collection/-/which-collection-1.0.2.tgz",
@@ -20450,15 +19399,6 @@
 			"license": "MIT",
 			"peerDependencies": {
 				"postcss": "^8"
-			}
-		},
-		"node_modules/webpack/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/agent-base": {
@@ -20912,15 +19852,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/regex-not/node_modules/safe-regex": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/safe-regex/-/safe-regex-1.1.0.tgz",
-			"integrity": "sha512-aJXcif4xnaNUzvUuC5gcb46oTS7zvg4jpMTnuqtrEPlR3vFr4pxtdTwaF1Qs3Enjn9HK+ZlwQui+a7z0SywIzg==",
-			"license": "MIT",
-			"dependencies": {
-				"ret": "~0.1.10"
-			}
-		},
 		"node_modules/stylelint/node_modules/ignore": {
 			"version": "7.0.5",
 			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
@@ -21105,18 +20036,6 @@
 				"url": "https://github.com/fb55/nth-check?sponsor=1"
 			}
 		},
-		"node_modules/regex-not/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@types/conventional-commits-parser": {
 			"version": "5.0.2",
 			"resolved": "https://registry.npmjs.org/@types/conventional-commits-parser/-/conventional-commits-parser-5.0.2.tgz",
@@ -21144,6 +20063,7 @@
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
 			"integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
@@ -21243,27 +20163,6 @@
 				"postcss": "^8.2.15"
 			}
 		},
-		"node_modules/webpack/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/copy-descriptor": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
-			"integrity": "sha512-XgZ0pFcakEUlbwQEVNg3+QAis1FyTL3Qel9FYy8pSkQqoG3PNoT0bOCQtOXcOkur21r2Eq2kI+IE+gsmAEVlYw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@types/babel__template": {
 			"version": "7.4.4",
 			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
@@ -21351,6 +20250,12 @@
 				"@webassemblyjs/wast-parser": "1.9.0",
 				"@xtuc/long": "4.2.2"
 			}
+		},
+		"node_modules/proxy-from-env": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+			"integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+			"license": "MIT"
 		},
 		"node_modules/@csstools/postcss-media-queries-aspect-ratio-number-values/node_modules/@csstools/media-query-list-parser": {
 			"version": "2.1.13",
@@ -21588,46 +20493,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/babel-code-frame/node_modules/strip-ansi": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-			"integrity": "sha512-VhumSSbBqDTP8p2ZLKj40UjBCV4+v8bUSEpUb4KjRgWk9pbqGF4REFj6KEagidb2f/M6AzC0EmFyDNGaw9OCzg==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-regex": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/to-regex": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.2.tgz",
-			"integrity": "sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==",
-			"license": "MIT",
-			"dependencies": {
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"regex-not": "^1.0.2",
-				"safe-regex": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/mixin-deep/node_modules/is-plain-object": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
-			"integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/cookie-signature": {
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.2.2.tgz",
@@ -21651,21 +20516,6 @@
 				"@webassemblyjs/wasm-opt": "1.9.0",
 				"@webassemblyjs/wasm-parser": "1.9.0",
 				"@webassemblyjs/wast-printer": "1.9.0"
-			}
-		},
-		"node_modules/class-utils": {
-			"version": "0.3.6",
-			"resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
-			"integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
-			"license": "MIT",
-			"dependencies": {
-				"arr-union": "^3.1.0",
-				"define-property": "^0.2.5",
-				"isobject": "^3.0.0",
-				"static-extend": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/@webassemblyjs/helper-wasm-section": {
@@ -21816,24 +20666,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/base": {
-			"version": "0.11.2",
-			"resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
-			"integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
-			"license": "MIT",
-			"dependencies": {
-				"cache-base": "^1.0.1",
-				"class-utils": "^0.3.5",
-				"component-emitter": "^1.2.1",
-				"define-property": "^1.0.0",
-				"isobject": "^3.0.1",
-				"mixin-deep": "^1.2.0",
-				"pascalcase": "^0.1.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/buffer-xor": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/buffer-xor/-/buffer-xor-1.0.3.tgz",
@@ -21937,28 +20769,6 @@
 				"des.js": "^1.0.0",
 				"inherits": "^2.0.1",
 				"safe-buffer": "^5.1.2"
-			}
-		},
-		"node_modules/nanomatch": {
-			"version": "1.2.13",
-			"resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
-			"integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
-			"license": "MIT",
-			"dependencies": {
-				"arr-diff": "^4.0.0",
-				"array-unique": "^0.3.2",
-				"define-property": "^2.0.2",
-				"extend-shallow": "^3.0.2",
-				"fragment-cache": "^0.2.1",
-				"is-windows": "^1.0.2",
-				"kind-of": "^6.0.2",
-				"object.pick": "^1.3.0",
-				"regex-not": "^1.0.0",
-				"snapdragon": "^0.8.1",
-				"to-regex": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/strip-json-comments": {
@@ -22457,15 +21267,6 @@
 				"@keyv/serialize": "^1.1.1"
 			}
 		},
-		"node_modules/snapdragon/node_modules/source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
-			"license": "BSD-3-Clause",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/hard-source-webpack-plugin/node_modules/chalk": {
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -22774,19 +21575,6 @@
 			"dev": true,
 			"license": "Python-2.0"
 		},
-		"node_modules/unset-value": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
-			"integrity": "sha512-PcA2tsuGSF9cnySLHTLSh2qrQiJ70mn+r+Glzxv2TWZblxsxCC52BDlZoPCsz7STd9pN7EZetkWZBAvk4cgZdQ==",
-			"license": "MIT",
-			"dependencies": {
-				"has-value": "^0.3.1",
-				"isobject": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@vue/babel-plugin-transform-vue-jsx": {
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/@vue/babel-plugin-transform-vue-jsx/-/babel-plugin-transform-vue-jsx-1.4.0.tgz",
@@ -22894,18 +21682,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/snapdragon-node/node_modules/define-property": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
-			"integrity": "sha512-cZTYKFWspt9jZsMscWo8sc/5lbPC9Q0N5nBLgb+Yd915iL3udB1uFgS3B8YCx66UVHq018DAVFoee7x+gxggeA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^1.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/minimist": {
@@ -23316,19 +22092,6 @@
 				"node": ">= 10.13.0"
 			}
 		},
-		"node_modules/static-extend/node_modules/is-descriptor": {
-			"version": "0.1.7",
-			"resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.7.tgz",
-			"integrity": "sha512-C3grZTvObeN1xud4cRWl366OMXZTj0+HGyk4hvfpx4ZHt1Pb60ANSXqCK7pdOTeUQpRzECBSTphqvD7U+l22Eg==",
-			"license": "MIT",
-			"dependencies": {
-				"is-accessor-descriptor": "^1.0.1",
-				"is-data-descriptor": "^1.0.1"
-			},
-			"engines": {
-				"node": ">= 0.4"
-			}
-		},
 		"node_modules/postcss-lab-function/node_modules/@csstools/css-color-parser": {
 			"version": "2.0.5",
 			"resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-2.0.5.tgz",
@@ -23698,15 +22461,6 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
-		"node_modules/pascalcase": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/pascalcase/-/pascalcase-0.1.1.tgz",
-			"integrity": "sha512-XHXfu/yOQRy9vYOtUDVMN60OEJjW013GoObG1o+xwQTpB9eYJX/BjXMsdW13ZDPruFhYYn0AG22w0xgQMwl3Nw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/postcss-html/node_modules/js-tokens": {
 			"version": "9.0.1",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
@@ -23885,22 +22639,6 @@
 			"license": "ISC",
 			"engines": {
 				"node": ">= 10"
-			}
-		},
-		"node_modules/watchpack-chokidar2/node_modules/fill-range": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/timers-browserify": {
@@ -24137,15 +22875,6 @@
 				"postcss": "^8.4.32"
 			}
 		},
-		"node_modules/arr-flatten": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/arr-flatten/-/arr-flatten-1.1.0.tgz",
-			"integrity": "sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/stop-iteration-iterator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/stop-iteration-iterator/-/stop-iteration-iterator-1.1.0.tgz",
@@ -24313,23 +23042,6 @@
 				"@babel/core": "^7.0.0-0"
 			}
 		},
-		"node_modules/babel-code-frame/node_modules/chalk": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-			"integrity": "sha512-U3lRVLMSlsCfjqYPbLyVv11M9CPW4I728d6TCKMAOJueEeB9/8o+eSsMnxPJD+Q+K909sdESg7C+tIkoH6on1A==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"ansi-styles": "^2.2.1",
-				"escape-string-regexp": "^1.0.2",
-				"has-ansi": "^2.0.0",
-				"strip-ansi": "^3.0.0",
-				"supports-color": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/postcss-minify-selectors/node_modules/postcss-selector-parser": {
 			"version": "7.1.0",
 			"resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-7.1.0.tgz",
@@ -24341,18 +23053,6 @@
 			},
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/webpack/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
-			"integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/hard-source-webpack-plugin/node_modules/parse-json": {
@@ -24507,18 +23207,6 @@
 				"postcss": "^8.4.32"
 			}
 		},
-		"node_modules/has-values/node_modules/kind-of": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-			"integrity": "sha512-24XsCxmEbRwEDbz/qz3stgin8TTzZ1ESR56OMCN0ujYg+vRutNSiOj9bHH9u85DKgXguraugV5sFuvbD4FW/hw==",
-			"license": "MIT",
-			"dependencies": {
-				"is-buffer": "^1.1.5"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@webassemblyjs/helper-buffer": {
 			"version": "1.9.0",
 			"resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.9.0.tgz",
@@ -24529,6 +23217,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
 			"integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-extendable": "^0.1.0"
@@ -24582,18 +23271,6 @@
 			},
 			"peerDependencies": {
 				"tslib": "2"
-			}
-		},
-		"node_modules/object-copy/node_modules/define-property": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
-			"integrity": "sha512-Rr7ADjQZenceVOAKop6ALkkRAmH1A4Gx9hV/7ZujPUN2rkATqFO0JZLZInbAjpZYoJ1gUx8MRMQVkYemcbMSTA==",
-			"license": "MIT",
-			"dependencies": {
-				"is-descriptor": "^0.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/brace-expansion": {
@@ -24939,21 +23616,6 @@
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/set-value": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.1.tgz",
-			"integrity": "sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==",
-			"license": "MIT",
-			"dependencies": {
-				"extend-shallow": "^2.0.1",
-				"is-extendable": "^0.1.1",
-				"is-plain-object": "^2.0.3",
-				"split-string": "^3.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/compression": {
 			"version": "1.8.1",
 			"resolved": "https://registry.npmjs.org/compression/-/compression-1.8.1.tgz",
@@ -25162,13 +23824,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/babel-traverse/node_modules/ms": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/follow-redirects": {
 			"version": "1.15.11",
 			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
@@ -25271,18 +23926,6 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/object-visit": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
-			"integrity": "sha512-GBaMwwAVK9qbQN3Scdo0OyvgPW7l3lnaVMj84uTOZlswkX0KpF6fyDBJhtTthf7pymztoN36/KEr1DyhF96zEA==",
-			"license": "MIT",
-			"dependencies": {
-				"isobject": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/concat-map": {
@@ -25483,15 +24126,6 @@
 				"tslib": "^2.0.3"
 			}
 		},
-		"node_modules/svgo/node_modules/nth-check": {
-			"version": "2.1.1",
-			"license": "BSD-2-Clause",
-			"resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
-			"integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
-			"dependencies": {
-				"boolbase": "~1.0.0"
-			}
-		},
 		"node_modules/@nuxtjs/style-resources/node_modules/consola": {
 			"version": "3.4.2",
 			"resolved": "https://registry.npmjs.org/consola/-/consola-3.4.2.tgz",
@@ -25599,6 +24233,7 @@
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
 			"integrity": "sha512-NOW9QQXMoZGg/oqnVNoNTTIFEIid1627WCffUBJEdMxYApq7mNE7CpzucIPc+ZQg25Phej7IJSmX3hO+oblOtQ==",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-buffer": "^1.1.5"
@@ -25948,21 +24583,6 @@
 				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
-		"node_modules/webpack/node_modules/fill-range": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
-			"integrity": "sha512-VcpLTWqWDiTerugjj8e3+esbg+skS3M9e54UuR3iCeIDMXCLTsAH8hTSzDQU/X6/6t3eYkOKoZSef2PlU6U1XQ==",
-			"license": "MIT",
-			"dependencies": {
-				"extend-shallow": "^2.0.1",
-				"is-number": "^3.0.0",
-				"repeat-string": "^1.6.1",
-				"to-regex-range": "^2.1.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/renderkid/node_modules/domhandler": {
 			"version": "4.3.1",
 			"resolved": "https://registry.npmjs.org/domhandler/-/domhandler-4.3.1.tgz",
@@ -26061,18 +24681,6 @@
 			"integrity": "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/split-string": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
-			"integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
-			"license": "MIT",
-			"dependencies": {
-				"extend-shallow": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/serialize-javascript": {
 			"version": "6.0.2",
@@ -26660,15 +25268,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/posix-character-classes": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/posix-character-classes/-/posix-character-classes-0.1.1.tgz",
-			"integrity": "sha512-xTgYBc3fuo7Yt7JbiuFxSYGToMoz8fLoE6TC9Wx1P/u+LfeThMOAqmuyECnlBaaJb+u1m9hHiXUEtwW4OzfUJg==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/ts-pnp": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/ts-pnp/-/ts-pnp-1.2.0.tgz",
@@ -26777,19 +25376,6 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/nanomatch/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@csstools/postcss-gamut-mapping/node_modules/@csstools/color-helpers": {
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-4.2.1.tgz",
@@ -26880,16 +25466,6 @@
 				"node": ">=10.13.0"
 			}
 		},
-		"node_modules/invariant": {
-			"version": "2.2.4",
-			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-			"integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"loose-envify": "^1.0.0"
-			}
-		},
 		"node_modules/webpack-sources": {
 			"version": "1.4.3",
 			"resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.4.3.tgz",
@@ -26955,19 +25531,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
 			"license": "MIT"
-		},
-		"node_modules/watchpack-chokidar2/node_modules/is-number": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-			"integrity": "sha512-4cboCqIpliH+mAvFNegjZQ4kgKc3ZUhQVr3HvWbSh5q3WH2v82ct+T2Y1hdU5Gdtorx/cLifQjqCbL7bpznLTg==",
-			"license": "MIT",
-			"optional": true,
-			"dependencies": {
-				"kind-of": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/@nuxtjs/svg-sprite/node_modules/chalk": {
 			"version": "4.1.2",
@@ -27104,23 +25667,6 @@
 				"balanced-match": "^1.0.0"
 			}
 		},
-		"node_modules/@vue/component-compiler-utils/node_modules/postcss": {
-			"version": "7.0.39",
-			"resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.39.tgz",
-			"integrity": "sha512-yioayjNbHn6z1/Bywyb2Y4s3yvDAeXGOyxqD+LnVOinq6Mdmd++SW2wUNVzavyyHxd6+DxzWGIuosg6P1Rj8uA==",
-			"license": "MIT",
-			"dependencies": {
-				"picocolors": "^0.2.1",
-				"source-map": "^0.6.1"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/postcss/"
-			}
-		},
 		"node_modules/eslint-plugin-es/node_modules/eslint-visitor-keys": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.3.0.tgz",
@@ -27129,19 +25675,6 @@
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=4"
-			}
-		},
-		"node_modules/regex-not/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/makeerror": {
@@ -27400,6 +25933,7 @@
 			"resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.3.tgz",
 			"integrity": "sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==",
 			"deprecated": "See https://github.com/lydell/source-map-resolve#deprecated",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"atob": "^2.1.2",
@@ -27994,16 +26528,6 @@
 				"@csstools/css-tokenizer": "^2.4.1"
 			}
 		},
-		"node_modules/watchpack-chokidar2/node_modules/micromatch/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"license": "MIT",
-			"optional": true,
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
 			"version": "10.4.3",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
@@ -28079,6 +26603,18 @@
 				"linux"
 			]
 		},
+		"node_modules/form-data/node_modules/mime-types": {
+			"version": "2.1.35",
+			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+			"integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "1.52.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
 		"node_modules/postcss-normalize-display-values": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/postcss-normalize-display-values/-/postcss-normalize-display-values-7.0.1.tgz",
@@ -28146,16 +26682,6 @@
 				"fsevents": "^1.2.7"
 			}
 		},
-		"node_modules/babel-messages": {
-			"version": "6.23.0",
-			"resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-			"integrity": "sha512-Bl3ZiA+LjqaMtNYopA9TYE9HP1tQ+E5dLxE0XrAzcIJeK2UqF0/EaqXwBn9esd4UmTfEab+P+UYQ1GnioFIb/w==",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"babel-runtime": "^6.22.0"
-			}
-		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "8.47.0",
 			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.47.0.tgz",
@@ -28215,6 +26741,22 @@
 			"peerDependencies": {
 				"@csstools/css-parser-algorithms": "^3.0.1",
 				"@csstools/css-tokenizer": "^3.0.1"
+			}
+		},
+		"node_modules/form-data": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+			"integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+			"license": "MIT",
+			"dependencies": {
+				"asynckit": "^0.4.0",
+				"combined-stream": "^1.0.8",
+				"es-set-tostringtag": "^2.1.0",
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
+			},
+			"engines": {
+				"node": ">= 6"
 			}
 		},
 		"node_modules/@types/jsdom": {
@@ -28494,15 +27036,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/nanomatch/node_modules/kind-of": {
-			"version": "6.0.3",
-			"resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
-			"integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/@nuxt/friendly-errors-webpack-plugin/node_modules/has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
@@ -28645,16 +27178,6 @@
 			"dependencies": {
 				"end-of-stream": "^1.1.0",
 				"stream-shift": "^1.0.0"
-			}
-		},
-		"node_modules/babel-code-frame/node_modules/ansi-styles": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-			"integrity": "sha512-kmCevFghRiWM7HB5zTPULl4r9bVFSWjz62MhqizDGUrq2NWuNMQyuv4tHHoKJHs69M/MF64lEcHdYIocrdWQYA==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/parse5": {
@@ -29052,19 +27575,10 @@
 			}
 		},
 		"node_modules/devalue": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/devalue/-/devalue-2.0.1.tgz",
-			"integrity": "sha512-I2TiqT5iWBEyB8GRfTDP0hiLZ0YeDJZ+upDxjBfOC2lebO5LezQMv7QvIUTzdb64jQyAKLf1AHADtGN+jw6v8Q==",
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/devalue/-/devalue-5.5.0.tgz",
+			"integrity": "sha512-69sM5yrHfFLJt0AZ9QqZXGCPfJ7fQjvpln3Rq5+PS03LD32Ost1Q9N+eEnaQwGRIriKkMImXD56ocjQmfjbV3w==",
 			"license": "MIT"
-		},
-		"node_modules/is-windows": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/is-windows/-/is-windows-1.0.2.tgz",
-			"integrity": "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==",
-			"license": "MIT",
-			"engines": {
-				"node": ">=0.10.0"
-			}
 		},
 		"node_modules/@babel/plugin-transform-nullish-coalescing-operator": {
 			"version": "7.27.1",
@@ -29091,19 +27605,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/has-values": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
-			"integrity": "sha512-ODYZC64uqzmtfGMEAX/FvZiRyWLpAC3vYnNunURUnkGVTS+mI0smVsWaPydRBsE3g+ok7h960jChO8mFcWlHaQ==",
-			"license": "MIT",
-			"dependencies": {
-				"is-number": "^3.0.0",
-				"kind-of": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/asn1.js": {
@@ -29328,21 +27829,23 @@
 			]
 		},
 		"node_modules/babel-traverse": {
-			"version": "6.26.0",
-			"resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
-			"integrity": "sha512-iSxeXx7apsjCHe9c7n8VtRXGzI2Bk1rBSOJgCCjfyXb6v1aCqE1KSEpq/8SXuVN8Ka/Rh1WDTF0MDzkvTA4MIA==",
+			"name": "@babel/traverse",
+			"version": "7.28.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.28.5.tgz",
+			"integrity": "sha512-TCCj4t55U90khlYkVV/0TfkJkAkUg3jZFA3Neb7unZT8CPok7iiRfaX0F+WnqWqt7OxhOn0uBKXCw4lbL8W0aQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"babel-code-frame": "^6.26.0",
-				"babel-messages": "^6.23.0",
-				"babel-runtime": "^6.26.0",
-				"babel-types": "^6.26.0",
-				"babylon": "^6.18.0",
-				"debug": "^2.6.8",
-				"globals": "^9.18.0",
-				"invariant": "^2.2.2",
-				"lodash": "^4.17.4"
+				"@babel/code-frame": "^7.27.1",
+				"@babel/generator": "^7.28.5",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.5",
+				"@babel/template": "^7.27.2",
+				"@babel/types": "^7.28.5",
+				"debug": "^4.3.1"
+			},
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@types/parse-json": {
@@ -29560,19 +28063,6 @@
 			},
 			"peerDependencies": {
 				"@csstools/css-tokenizer": "^2.4.1"
-			}
-		},
-		"node_modules/webpack/node_modules/micromatch/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
-			"integrity": "sha512-BwY5b5Ql4+qZoefgMj2NUmx+tehVTH/Kf4k1ZEtOHNFcm2wSxMRo992l6X3TIgni2eZVTZ85xMOjF31fwZAj6Q==",
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/jest-watcher/node_modules/chalk": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.3.5",
+	"version": "2.3.6",
 	"private": true,
 	"name": "nuxt-course",
 	"description": "Udemy course by Maximilian Schwarzmüller about Nuxt.js 2 Framework - Vue.js on Steroids. Build highly engaging Vue JS apps with Nuxt.js. Nuxt adds easy server-side-rendering and a folder-based config approach.",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,25 @@
 		"json5": "2.2.3",
 		"nth-check": "2.1.1"
 	},
+	"overrides": {
+		"braces": "^3.0.3",
+		"micromatch": "^4.0.8",
+		"postcss": "^8.5.6",
+		"cookie": "^0.7.2",
+		"devalue": "^5.3.2",
+		"tmp": "^0.2.4",
+		"@babel/traverse": "^7.28.0",
+		"axios": "^1.9.0",
+		"http-proxy-middleware": "^3.0.5",
+		"nth-check": "^2.1.1",
+		"vue-jest": {
+			"babel-plugin-transform-es2015-modules-commonjs": {
+				"babel-template": {
+					"babel-traverse": "npm:@babel/traverse@^7.28.0"
+				}
+			}
+		}
+	},
 	"engines": {
 		"node": "20.18.0",
 		"npm": "10.8.2"


### PR DESCRIPTION
# fix(deps): add overrides to reduce security vulnerabilities

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | S | 22-11-2025 | 22-11-2025 |

## 📸 Screenshots

| Current | Expected |
| :---: | :---: |
| <img width="834" alt="Screenshot 2025-11-22 a las 20 28 48" src="https://github.com/user-attachments/assets/b6e1f533-a1dc-48eb-b98b-0dc77fc7ba81" /> | <img width="728" alt="Screenshot 2025-11-22 a las 20 30 14" src="https://github.com/user-attachments/assets/0432ea9c-456c-484a-9535-17a8cbbec76d" /> |

## 📝 Summary

> [!CAUTION]
> ```bash
> $ npm audit
> 50 vulnerabilities (7 low, 14 moderate, 25 high, 4 critical)
> ```

- Add npm `overrides` section to `package.json` to force secure versions of transitive dependencies
- Silence `TypeScript` `baseUrl` deprecation warning in `jsconfig.json`
- Reduce security vulnerabilities from 50 to 18 (64% reduction), eliminating all CRITICAL severity issues

## 💡 Why this bug?

- The project has 50 security vulnerabilities (4 CRITICAL, 25 HIGH) in transitive dependencies
- Several vulnerable packages (`babel-traverse`, `axios`, `http-proxy-middleware`) cannot be updated directly because they are nested deep in the dependency tree
- The `baseUrl` option in `jsconfig.json` triggers a deprecation warning with newer `TypeScript` versions

## ✅ Expected behavior

- Security vulnerabilities should be reduced to the minimum achievable without major breaking changes
- All CRITICAL severity vulnerabilities should be eliminated
- The `jsconfig.json` deprecation warning should be silenced

## 📋 Steps

### Phase 1: Add security overrides
- [ ] Add `overrides` section to `package.json` with secure versions of:
  - `braces`: `^3.0.3` (fixes ReDoS vulnerability)
  - `micromatch`: `^4.0.8` (fixes ReDoS vulnerability)
  - `postcss`: `^8.5.6` (fixes line return parsing error)
  - `cookie`: `^0.7.2` (fixes cookie parsing vulnerability)
  - `devalue`: `^5.3.2` (fixes prototype pollution)
  - `tmp`: `^0.2.4` (fixes insecure temporary file creation)
  - `@babel/traverse`: `^7.28.0` (fixes arbitrary code execution)
  - `axios`: `^1.9.0` (fixes SSRF vulnerability)
  - `http-proxy-middleware`: `^3.0.5` (fixes authentication bypass)
  - `nth-check`: `^2.1.1` (fixes ReDoS vulnerability)
  - `vue-jest` > `babel-plugin-transform-es2015-modules-commonjs` > `babel-template` > `babel-traverse`: `npm:@babel/traverse@^7.28.0` (eliminates CRITICAL Babel 6 vulnerabilities)
- [ ] Update `package-lock.json` with new dependency resolutions

### Phase 2: Fix configuration warning
- [ ] Add `ignoreDeprecations: "5.0"` to `jsconfig.json` to silence `baseUrl` deprecation warning

### Phase 3: Bump version
- [ ] Bump version from `2.3.5` to `2.3.6`

## 🧪 Tests

- [ ] Verify vulnerability reduction:

```bash
npm audit
```
- [ ] Confirm application builds without errors:

```bash
npm run build
```
- [ ] Verify lint passes without errors:

```bash
npm run lint
```
- [ ] Verify dev server starts successfully:

```bash
npm run dev
```
- [ ] Verify Jest tests pass:

```bash
npm run test
```
- [ ] Verify no regression in existing functionality

## 📌 Notes

### Vulnerable packages
| Package | Version | Severity | Dependency chain | Advisory |
| --- | --- | --- | --- | --- |
| `babel-traverse` | `<7.0.0` | ⚫ | `vue-jest` → `babel-template` → `babel-traverse` | [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) |
| `ip` | `<2.0.1` | 🔴 | `nuxt` → `webpack-dev-server` → `ip` | [GHSA-2p57-rm9w-gvfp](https://github.com/advisories/GHSA-2p57-rm9w-gvfp) |
| `lodash.template` | `<4.5.0` | 🔴 | `nuxt` → `@nuxt/builder` → `lodash.template` | [GHSA-35jh-r3h4-6jhm](https://github.com/advisories/GHSA-35jh-r3h4-6jhm) |
| `parse-git-config` | `<3.0.0` | 🔴 | `nuxt` → `@nuxt/cli` → `parse-git-config` | [GHSA-8g77-54rh-46hx](https://github.com/advisories/GHSA-8g77-54rh-46hx) |
| `braces` | `<3.0.3` | 🔴 | `nuxt` → `chokidar` → `braces` | — |
| `axios` | `≤0.30.1` | 🔴 | `@nuxtjs/axios` → `axios` | — |
| `postcss` | `<8.5.6` | 🟡 | `nuxt` → `postcss` | [GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx) |
| `vue` | `2.7.16` | 🔴 | Direct dependency | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) |
| `vue-template-compiler` | `2.7.16` | 🟡 | Direct dependency | — |

### Security overrides
| Package | Version | Severity | Advisory |
| --- | --- | --- | --- |
| `@babel/traverse` | `7.28.0` | ⚫ | [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) |
| `babel-traverse` | `7.28.0` | ⚫ | [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92) |
| `braces` | `3.0.3` | 🔴 | [GHSA-grv7-fg5c-xmjg](https://github.com/advisories/GHSA-grv7-fg5c-xmjg) |
| `micromatch` | `4.0.8` | 🔴 | [GHSA-952p-6rrq-rcjv](https://github.com/advisories/GHSA-952p-6rrq-rcjv) |
| `axios` | `1.9.0` | 🔴 | [GHSA-43fc-jf86-j433](https://github.com/advisories/GHSA-43fc-jf86-j433) |
| `http-proxy-middleware` | `3.0.5` | 🔴 | [GHSA-c7qv-q95q-8v27](https://github.com/advisories/GHSA-c7qv-q95q-8v27) |
| `nth-check` | `2.1.1` | 🔴 | [GHSA-rp65-9cf3-cjxr](https://github.com/advisories/GHSA-rp65-9cf3-cjxr) |
| `postcss` | `8.5.6` | 🟡 | [GHSA-7fh5-64p2-3v2j](https://github.com/advisories/GHSA-7fh5-64p2-3v2j) |
| `cookie` | `0.7.2` | 🟡 | [GHSA-pxg6-pf52-xh8x](https://github.com/advisories/GHSA-pxg6-pf52-xh8x) |
| `devalue` | `5.3.2` | 🟡 | [GHSA-vj54-72f3-p5jv](https://github.com/advisories/GHSA-vj54-72f3-p5jv) |
| `tmp` | `0.2.4` | 🟡 | [GHSA-52f5-9888-hmc6](https://github.com/advisories/GHSA-52f5-9888-hmc6) |

### Vulnerability reduction summary after fix
| Severity | Before | After | Reduction |
| --- | --- | --- | --- |
| ⚫ CRITICAL | 4 | 0 | 100% |
| 🔴 HIGH | 25 | 9 | 64% |
| 🟡 MODERATE | 14 | 7 | 50% |
| 🟢 LOW | 7 | 2 | 71% |
| **TOTAL** | **50** | **18** | **64%** |

> [!CAUTION]
> ```bash
> $ npm audit
> 18 vulnerabilities (2 low, 7 moderate, 9 high)
> ```

**Reduction:** 50 → 18 vulnerabilities (64% reduction, all CRITICAL severity resolved)

### Remaining vulnerabilities after fix
| Package | Version | Why it can't be fixed | Advisory |
| --- | --- | --- | --- |
| `vue` | `2.7.16` | Requires `vue@3` upgrade<br>(major breaking change) | [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx) |
| `vuex` | `3.x` | Requires `vue@3` upgrade | — |
| `nuxt` | `2.x` | Requires `nuxt@3` upgrade<br>(major breaking change) | — |
| `@nuxt/core` | `2.x` | Requires `nuxt@3` upgrade | — |
| `@vue/test-utils` | `1.x` | Requires `vue@3` upgrade | — |
| `vue-template-compiler` | `2.x` | Requires `vue@3` upgrade | — |

All remaining 18 vulnerabilities require upgrading to `nuxt@3` and `vue@3`, which is a complete application migration beyond the scope of this fix.

## 🔗 References

### Documentation
- [GHSA-67hx-6x53-jw92](https://github.com/advisories/GHSA-67hx-6x53-jw92)
- [GHSA-2p57-rm9w-gvfp](https://github.com/advisories/GHSA-2p57-rm9w-gvfp)
- [GHSA-35jh-r3h4-6jhm](https://github.com/advisories/GHSA-35jh-r3h4-6jhm)
- [GHSA-8g77-54rh-46hx](https://github.com/advisories/GHSA-8g77-54rh-46hx)
- [GHSA-5j4c-8p2g-v4jx](https://github.com/advisories/GHSA-5j4c-8p2g-v4jx)
- [GHSA-g3ch-rx76-35fx](https://github.com/advisories/GHSA-g3ch-rx76-35fx)
- https://docs.npmjs.com/cli/v8/configuring-npm/package-json#overrides

### Related Issues
- Closes #947