### PR TITLE
hotfix(2.5.1): update commitlint config to match standard across repositories

### DIFF
--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -8,6 +8,10 @@ export default {
 			"always",
 			10000,
 		],
+		"footer-leading-blank": [
+			0,
+			"always",
+		],
 		"footer-max-line-length": [
 			2,
 			"always",

--- a/commitlint.config.js
+++ b/commitlint.config.js
@@ -17,5 +17,26 @@ export default {
 			"always",
 			10000,
 		],
+		"header-max-length": [
+			2,
+			"always",
+			150,
+		],
+		"type-enum": [
+			2,
+			"always",
+			[
+				"build",
+				"ci",
+				"docs",
+				"feat",
+				"fix",
+				"perf",
+				"refactor",
+				"revert",
+				"style",
+				"test",
+			],
+		],
 	},
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "nuxt-course",
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "nuxt-course",
-			"version": "2.5.0",
+			"version": "2.5.1",
 			"hasInstallScript": true,
 			"license": "ISC",
 			"dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"version": "2.5.0",
+	"version": "2.5.1",
 	"private": true,
 	"name": "nuxt-course",
 	"description": "Udemy course by Maximilian Schwarzmüller about Nuxt.js 2 Framework - Vue.js on Steroids. Build highly engaging Vue JS apps with Nuxt.js. Nuxt adds easy server-side-rendering and a folder-based config approach.",


### PR DESCRIPTION
# hotfix(2.5.1): update commitlint config to match standard across repositories

| ⏱️ Estimate | 📊 Priority | 📏 Size | 📅 Start | 📅 End |
| --- | --- | --- | --- | --- |
| 1h | P3 | XS | 22-12-2025 | 22-12-2025 |

## 📸 Screenshots

| Before | After |
| :---: | :---: |
| N/A — This change has no visual impact. | N/A — This change has no visual impact. |

## 🔄 Type of Change

- [x] Bug fix
- [ ] Breaking change
- [x] Dependency
- [ ] New feature
- [ ] Improvement
- [x] Configuration
- [x] Documentation
- [x] CI/CD

## 📝 Summary

- Update commitlint configuration to match the standard used across all repositories (like `beatrizsmerino`) the commitlint configuration to match the standard used across all repositories (like `beatrizsmerino`).

## 📋 Changes Made

### Configuration
- Add `footer-leading-blank` rule disabled (value 0) to avoid warnings
- Add `header-max-length` rule with 150 characters limit
- Add `type-enum` rule with standard conventional commit types: `build`, `ci`, `docs`, `feat`, `fix`, `perf`, `refactor`, `revert`, `style`, `test`

### Version
- Bump version from `2.5.0` to `2.5.1`

## 🧪 Tests

- [x] Verify build completes without errors:

```bash
npm run build
```
- [x] Verify code follows the project's style guidelines
- [x] Perform manual self-review of the code
- [x] Verify commits don't show `footer-leading-blank` warning

## 📌 Notes

- The commitlint configuration was inconsistent with other repositories, causing warnings like `footer must have leading blank line [footer-leading-blank]` during commits.

## 🔗 References

### Related Issues
- Closes #990